### PR TITLE
Layout: remove default unset

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -78,7 +78,6 @@ function generateSizesStyles(selector: string, sizes: Size[]) {
 
     const inlineStyles = `
         ${selector} > :nth-child(${index + 1}) {
-          display: ${basicSize === 0 ? 'none' : 'unset'};
           flex: ${canGrow ? '1' : '0'} ${canShrink ? '1' : '0'} ${size};
           max-width: ${size};
         }


### PR DESCRIPTION
Bad fix introduced in https://github.com/Shopify/post-purchase-ui/pull/5

More context in main repo:
https://github.com/Shopify/checkout-web/pull/8359